### PR TITLE
Convert README.md to README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,8 +6,6 @@
 :linkattrs:
 :source-highlighter: pygments
 :pygments-style: tango
-:allow-uri-read:
-:sourcedir: src/main/groovy/com/lucidworks/storm/example/twitter
 
 Tools for building Storm topologies for indexing data into SolrCloud.
 
@@ -16,6 +14,7 @@ Tools for building Storm topologies for indexing data into SolrCloud.
 * Send objects from a Storm topology into Solr.
 * Support for SolrCloud.
 
+// tag::storm-build[]
 == Getting Started
 
 First, build the Jar for this project:
@@ -28,7 +27,7 @@ This will generate the `target/storm-solr-1.0.jar` that contains the Storm JAR n
 
 To begin, let’s understand how to run a topology in Storm. Effectively, there are two basic modes of running a Storm topology: local and cluster mode. Local mode is great for testing your topology locally before pushing it out to a remote Storm cluster, such as staging or production. For starters, you need to compile and package your code and all of its dependencies into a single JAR with an main class that runs your topology.
 
-For this project, I chose the Maven Shade plugin to create the unified JAR with dependencies. The benefit of the Shade plugin is that it can relocate classes into different packages at the byte-code level to avoid dependency conflicts. This comes in quite handy if your application depends on 3rd party libraries that conflict with classes on the Storm classpath. You can look at the project pom.xml file for specific details about I use the Shade plugin. For now, let it suffice to say that the project makes it very easy to build a Storm JAR for your application. Once you have a unified JAR (storm-solr-1.0.jar), you’re ready to run your topology in Storm.
+For this project, the Maven Shade plugin is used to create a unified JAR with dependencies. The benefit of the Shade plugin is that it can relocate classes into different packages at the byte-code level to avoid dependency conflicts. This comes in quite handy if your application depends on 3rd party libraries that conflict with classes on the Storm classpath. You can look at the project pom.xml file for specific details about I use the Shade plugin. For now, let it suffice to say that the project makes it very easy to build a Storm JAR for your application. Once you have a unified JAR (storm-solr-1.0.jar), you’re ready to run your topology in Storm.
 
 To run locally, you need to have some code that starts up a local cluster in the JVM, submits your topology, and then waits for some configurable amount of time before shutting it all back down, as shown in the following code:
 
@@ -37,7 +36,7 @@ To run locally, you need to have some code that starts up a local cluster in the
 LocalCluster cluster = new LocalCluster();
 cluster.submitTopology(topologyName, stormConf, topologyFactory.build(this));
 try {
- Thread.sleep(localRunSecs * 1000);
+   Thread.sleep(localRunSecs * 1000);
 } catch (InterruptedException ie) { ... }
 cluster.killTopology(topologyName);
 cluster.shutdown();
@@ -50,46 +49,92 @@ However, if you want to run your topology in a remote cluster, such as productio
 StormSubmitter.submitTopology(topologyName, stormConf, topologyFactory.build(this));
 ----
 
-Consequently, the first thing you’ll need is some way to decide whether to run locally or submit to a remote cluster using some command-line switch when invoking your application. You’ll also need some way to pass along environment specific configuration options. For instance, the Solr you want to index into will be different between local, staging, and production. Let it suffice to say that launching and configuring a Storm topology ends up requiring a fair amount of common boilerplate code. To address this need, our project provides the com.lucidworks.storm.StreamingApp class that does the following:
+Consequently, the first thing you’ll need is some way to decide whether to run locally or submit to a remote cluster using some command-line switch when invoking your application. You’ll also need some way to pass along environment specific configuration options. For instance, the Solr you want to index into will be different between local, staging, and production. Let it suffice to say that launching and configuring a Storm topology ends up requiring a fair amount of common boilerplate code. To address this need, our project provides a `com.lucidworks.storm.StreamingApp` class that:
 
 * Separates the process of defining a Storm topology from the process of running a Storm topology in different environments. This lets you focus on defining a topology for your specific requirements.
 * Provides a clean mechanism for separating environment-specific configuration settings.
 * Minimizes duplicated boilerplate code when developing multiple topologies and gives you a common place to insert reusable logic needed for all of your topologies.
 
-To use StreamingApp, you simply need to implement the StormTopologyFactory interface, which defines the spouts and bolts in your topology:
+To use `StreamingApp`, you simply need to implement the `StormTopologyFactory` interface, which defines the spouts and bolts in your topology:
 
 [source,java]
 ----
 public interface StormTopologyFactory {
- String getName();
+   String getName();
 
- StormTopology build(StreamingApp app) throws Exception;
+   StormTopology build(StreamingApp app) throws Exception;
 }
 ----
 
-== Developing a Storm Topology
+// end::storm-build[]
 
+// tag::mapr[]
+=== Working with MaprFS
+
+First, build the jar with MapR 5 dependencies.
+
+[literal]
+mvn clean package -Dmaven.test.skip=true -Dhadoop-version=mapr5
+
+This will generate the `target/storm-solr-1.0-mapr5-SNAPSHOT.jar` that contains the Storm JAR needed to deploy a topology.
+
+In order to execute the `hdfs-to-solr` example, add the spring `fs.hdfs.impl` property to your `resources/Config.groovy` file with the `com.mapr.fs.MapRFileSystem` value. Also, change the `fs.defaultFS` property to use the maprfs schema.
+
+[source,groovy]
+----
+   spring.fs.defaultFS = "maprfs://cldbhost:port"
+   spring.fs.hdfs.impl = "com.mapr.fs.MapRFileSystem"
+
+----
+// end::mapr[]
+
+// tag::topology[]
+== Developing a Storm Topology
 
 Let's look at an example that indexes tweets from Twitter into SolrCloud.
 
+// tag::twitter-example[]
 === TwitterToSolrTopology
 
-[source,java]
+[source,groovy]
 ----
-include::{sourcedir}/TwitterToSolrTopology.groovy[lines="12..22,29..-1"]
+class TwitterToSolrTopology implements StormTopologyFactory {
+   static final Fields spoutFields = new Fields("id", "tweet")
+
+   String getName() { return "twitter-to-solr" }
+
+   StormTopology build(StreamingApp app) throws Exception {
+      // setup spout and bolts for accessing Spring-managed POJOs at runtime
+      SpringSpout twitterSpout = new SpringSpout("twitterDataProvider", spoutFields);
+      SpringBolt solrBolt = new SpringBolt("solrBoltAction", app.tickRate("solrBolt"));
+
+      // wire up the topology to read tweets and send to Solr
+      TopologyBuilder builder = new TopologyBuilder()
+      builder.setSpout("twitterSpout", twitterSpout, app.parallelism("twitterSpout"))
+      builder.setBolt("solrBolt", solrBolt, numShards).customGrouping("twitterSpout", shardGrouping)
+
+   return builder.createTopology()
+  }
+}
 ----
 
-A couple of things should stand out to you in this listing. First, there’s no command-line parsing, environment-specific configuration handling, or any code related to running this topology. All that you see here is code defining a StormTopology. Second, the code is quite easy to understand because it only does one thing. Lastly, this class is written in Groovy instead of Java, which helps keep things nice and tidy and I find Groovy to be more enjoyable to write. Of course if you don’t want to use Groovy, you can use Java, as the framework supports both seamlessly.
+A couple of things should stand out to you in this listing. First, there’s no command-line parsing, environment-specific configuration handling, or any code related to running this topology. All that is here is code defining a StormTopology.
 
-We’ll get into the specific details of the implementation shortly, but first, let’s see how to run the TwitterToSolrTopology using the StreamingApp framework. For local mode, you would do:
+Second, the code is quite easy to understand because it only does one thing.
 
-[source]
-----
+Lastly, this class is written in Groovy instead of Java, which helps keep things nice and tidy. Of course if you don’t want to use Groovy, you can use Java, as the framework supports both seamlessly.
+
+We’ll get into the specific details of the implementation shortly, but first, let’s see how to run the TwitterToSolrTopology using the `StreamingApp` framework. For local mode, you would do:
+
+[literal]
+....
 java -classpath $STORM_HOME/lib/*:target/storm-solr-1.0.jar com.lucidworks.storm.StreamingApp \
    example.twitter.TwitterToSolrTopology -localRunSecs 90
-----
+....
 
-The command above will run the TwitterToSolrTopology for 90 seconds on your local workstation and then shutdown. All the setup work is provided by the StreamingApp class. To submit to a remote cluster, you would do:
+The command above will run the TwitterToSolrTopology for 90 seconds on your local workstation and then shutdown. All the setup work is provided by the `StreamingApp` class.
+
+To submit to a remote cluster, you would do:
 
 [literal]
 ....
@@ -97,14 +142,13 @@ $STORM_HOME/bin/storm jar target/storm-solr-1.0.jar com.lucidworks.storm.Streami
    example.twitter.TwitterToSolrTopology -env staging
 ....
 
-Notice that I’m using the -env flag to indicate I’m running in my staging environment. It’s common to need to run a Storm topology in different environments, such as test, staging, and production, so that’s built into the StreamingApp framework.
+Notice that we use the `-env` flag to indicate running in a staging environment. It’s common to need to run a Storm topology in different environments, such as test, staging, and production, so it's built into the `StreamingApp` framework.
+// end::twitter-example[]
 
+// tag::spring-bolt[]
 === SpringBolt
 
-The `com.lucidworks.storm.spring.SpringBolt` class allows you to implement your bolt logic as a simple
-Spring-managed POJO. In the example above, the `SpringBolt` class delegates message processing logic to a
-Spring-managed bean with id `solrBoltAction`. The `solrBoltAction` bean is defined in the Spring container
-configuration file `resources/spring.xml` as:
+The `com.lucidworks.storm.spring.SpringBolt` class allows you to implement your bolt logic as a simple Spring-managed POJO. In the example above, the `SpringBolt` class delegates message processing logic to a Spring-managed bean with id `solrBoltAction`. The `solrBoltAction` bean is defined in the Spring container configuration file `resources/spring.xml` as:
 
 [source,xml]
 ----
@@ -130,14 +174,15 @@ by the Spring framework:
 ----
 
 The `zkHost` and `defaultCollection` properties are defined in `resources/Config.groovy`
+// end::spring-bolt[]
 
+//tag::spring-spout[]
 === SpringSpout
 
 In Storm, a spout produces a stream of tuples. The TwitterToSolrTopology example uses an instance of SpringSpout and a Twitter data provider to stream tweets into the topology:
 
-[literal]
+[source,java]
 SpringSpout twitterSpout = new SpringSpout("twitterDataProvider", spoutFields);
-
 
 SpringSpout allows you to focus on the application-specific logic needed to generate data without having to worry about Storm specific implementation details. As you might have guessed, the data provider is a Spring-managed POJO that implements the StreamingDataProvider interface:
 
@@ -151,11 +196,14 @@ public interface StreamingDataProvider {
 ----
 
 Take a look at the TwitterDataProvider implementation provided in the project as a starting point for implementing a Spring-managed bean for your topology.
+// end::spring::spout[]
 
-
+// tag::unit-test[]
 === Unit Testing
 
-When writing a unit test, you don’t want to have to spin up a Storm cluster to test application-specific logic that doesn’t depend on Storm. Recall that one of the benefits of using this framework is that it separates business logic from Storm boilerplate code. Let’s look at some code from the unit test for our SolrBoltAction implementation.
+When writing a unit test, you don’t want to have to spin up a Storm cluster to test application-specific logic that doesn’t depend on Storm. Recall that one of the benefits of using this framework is that it separates business logic from Storm boilerplate code.
+
+Let’s look at some code from the unit test for our `SolrBoltAction` implementation.
 
 [source,java]
 ----
@@ -179,15 +227,23 @@ public void testBoltAction() throws Exception {
 }
 ----
 
-The first thing that you should notice is the unit test doesn’t need a Storm cluster to run. This makes your tests run quickly and helps isolate bugs since there are fewer runtime dependencies in this test. It’s also important to notice that the SolrBoltAction implementation is not running in a Spring-managed container in this unit test. We’re just creating the instance directly using the new operator. This is good test design as well since you don’t want to create a Spring container for every unit test and testing the Spring configuration is not the responsibility of this particular unit test.
+The first thing to notice is the unit test doesn’t need a Storm cluster to run. This makes tests run quickly and helps isolate bugs since there are fewer runtime dependencies in this test.
 
-The unit test is also using Mockito to mock the Storm Tuple object that is passed into SolrBoltAction. Mockito makes it easy to mock complex objects in a unit test. The key take-away here is that the unit test focuses on verifying the SolrBoltAction implementation without having to worry about Storm or Spring.
+It’s also important to notice that the `SolrBoltAction` implementation is not running in a Spring-managed container in this unit test. We’re just creating the instance directly using the new operator. This is good test design as well since you don’t want to create a Spring container for every unit test and testing the Spring configuration is not the responsibility of this particular unit test.
 
+The unit test is also using Mockito to mock the Storm Tuple object that is passed into `SolrBoltAction`. Mockito makes it easy to mock complex objects in a unit test.
+
+The key take-away here is that the unit test focuses on verifying the `SolrBoltAction` implementation without having to worry about Storm or Spring.
+// end::unit-test[]
+
+// tag::env-config[]
 === Environment-specific Configuration
 
-I’ve implemented several production Storm topologies in the past couple years and one pattern that keeps emerging is the need to manage configuration settings for different environments. For instance, we’ll need to index into a different SolrCloud cluster for staging and production. To address this need, the Spring-driven framework allows you to keep all environment-specific configuration properties in the same configuration file: `Config.groovy`.
+Commonly, you will need to manage configuration settings for different environments. For instance, we’ll need to index into a different SolrCloud cluster for staging and production. To address this need, the Spring-driven framework allows you to keep all environment-specific configuration properties in the same configuration file: `Config.groovy`.
 
-Don't worry if you don't know Groovy, the syntax of the `Config.groovy` file is very easy to understand and allows you to cleanly separate properties for the following environments: test, dev, staging, and production. Put simply, this approach allows you to run the topology in multiple environments using a simple command-line switch to specify the environment settings that should be applied -env. Here’s an example of `Config.groovy` that shows how to organize properties for the test, development, staging, and production environments:
+Don't worry if you don't know http://www.groovy-lang.org/[Groovy], the syntax of the `Config.groovy` file is easy to understand and allows you to cleanly separate properties for the following environments: test, dev, staging, and production. This approach allows you to run the topology in multiple environments using a simple command-line switch, `-env`, to specify the environment settings that should be applied.
+
+Here’s an example of `Config.groovy` that shows how to organize properties for the test, development, staging, and production environments:
 
 [source,groovy]
 ----
@@ -233,11 +289,13 @@ environments {
 }
 ----
 
-Notice that all dynamic variables used in the resources/storm-solr-spring.xml must be prefixed with "spring." in `Config.groovy`. For instance, the ${zkHost} setting in storm-solr-spring.xml resolves to the spring.zkHost property in `Config.groovy`.
+Notice that all dynamic variables used in the resources/storm-solr-spring.xml must be prefixed with "spring." in `Config.groovy`. For instance, the `${zkHost}` setting in `storm-solr-spring.xml` resolves to the `spring.zkHost` property in `Config.groovy`.
 
-You can also configure all Storm-topology related properties in the `Config.groovy` file. For instance, if you need to change the topology.max.task.parallelism property for your topology, you can set that in `Config.groovy`.
+You can also configure all Storm-topology related properties in the `Config.groovy` file. For instance, if you need to change the `topology.max.task.parallelism property` for your topology, you can set that in `Config.groovy`.
 
-When adapting the project to your own requirements, the easiest approach is to update the `resources/Config.groovy` with the configuration settings for each of your environments and then rebuild the Job JAR. However, you can also specify a different `Config.groovy` file by using the -config command-line option when deploying the topology, such as:
+When adapting the project to your own requirements, the easiest approach is to update `resources/Config.groovy` with the configuration settings for each of your environments and then rebuild the Job JAR.
+
+However, you can also specify a different `Config.groovy` file by using the `-config` command-line option when deploying the topology, such as:
 
 [literal]
 ....
@@ -245,11 +303,14 @@ $STORM_HOME/bin/storm jar target/storm-solr-1.0.jar com.lucidworks.storm.Streami
    example.twitter.TwitterToSolrTopology -env staging -config MyConfig.groovy
 ....
 
+// end::env-config[]
+
+// tag::metrics[]
 === Metrics
 
-Storm provides high-level metrics for bolts and spouts, but if you need more visibility into the inner workings of your application-specific logic, then it’s common to use the Java metrics library, see: https://dropwizard.github.io/metrics/3.1.0/. Fortunately, there are open source options for integrating metrics with Spring, see: https://github.com/ryantenney/metrics-spring.
+Storm provides high-level metrics for bolts and spouts, but if you need more visibility into the inner workings of your application-specific logic, then it’s common to use the Java metrics library, such as: https://dropwizard.github.io/metrics/3.1.0/. Fortunately, there are open source options for integrating metrics with Spring, see: https://github.com/ryantenney/metrics-spring.
 
-The Spring context configuration file resources/storm-solr-spring.xml comes pre-configured with all the infrastructure needed to inject metrics into your bean implementations:
+The Spring context configuration file `resources/storm-solr-spring.xml` comes pre-configured with all the infrastructure needed to inject metrics into your bean implementations:
 
 [source,xml]
 ----
@@ -260,7 +321,7 @@ The Spring context configuration file resources/storm-solr-spring.xml comes pre-
 
 By default, the project is configured to log metrics once a minute to the Storm log using the slf4j reporter.
 
-When implementing your StreamingDataAction (bolt) or StreamingDataProvider (spout), you can have Spring auto-wire metrics objects using the @Metric annotation when declaring metrics-related member variables. For instance, the SolrBoltAction class uses a Timer to track how long it takes to send batches to Solr.
+When implementing your `StreamingDataAction` (bolt) or `StreamingDataProvider` (spout), you can have Spring auto-wire metrics objects using the `@Metric` annotation when declaring metrics-related member variables. For instance, the `SolrBoltAction` class uses a `Timer` to track how long it takes to send batches to Solr:
 
 [source,java]
 ----
@@ -268,17 +329,19 @@ When implementing your StreamingDataAction (bolt) or StreamingDataProvider (spou
 public Timer sendBatchToSolr;
 ----
 
-The SolrBoltAction class provides several examples of how to use metrics in your bean implementations.
+The `SolrBoltAction` class provides several examples of how to use metrics in your bean implementations.
 
-Before moving on to some Solr specific features in the framework, I want drive home one more point. The example Twitter topology we’ve been working with in this blog is quite trivial. In practice, most topologies are more complex and have many spouts and bolts, typically written by multiple developers. Moreover, topologies tend to evolve over time to incorporate data from new systems and requirements. Using this framework will help you craft complex topologies in a simple, maintainable fashion.
+Before moving on to some Solr specific features in the framework, it's important to remember one more point. The example Twitter topology we’ve been working with in this blog is quite trivial. In practice, most topologies are more complex and have many spouts and bolts, typically written by multiple developers. Moreover, topologies tend to evolve over time to incorporate data from new systems and requirements. Using this framework will help you craft complex topologies in a simple, maintainable fashion.
+// end::metrics[]
 
+// tag::field-mapping[]
 === Field Mapping
 
-The SolrBoltAction bean takes care of sending documents to SolrCloud in an efficient manner, but it only works with SolrInputDocument objects from SolrJ. It’s unlikely that your Storm topology will be working with SolrInputDocument objects natively, so the SolrBoltAction bean delegates mapping of input Tuples to SolrInputDocument objects to a Spring-managed bean that implements the com.lucidworks.storm.solr.SolrInputDocumentMapper interface. This fits nicely with our design approach of separating concerns in our topology.
+The `SolrBoltAction` bean takes care of sending documents to SolrCloud in an efficient manner, but it only works with SolrInputDocument objects from SolrJ. It’s unlikely that your Storm topology will be working with SolrInputDocument objects natively, so the `SolrBoltAction` bean delegates mapping of input Tuples to SolrInputDocument objects to a Spring-managed bean that implements the `com.lucidworks.storm.solr.SolrInputDocumentMapper` interface. This fits nicely with our design approach of separating concerns in our topology.
 
-The default implementation provided in the project (DefaultSolrInputDocumentMapper) uses Java reflection to read data from a Java object to populate the fields of the SolrInputDocument. In the Twitter example, the default implementation uses Java reflection to read data from a Twitter4J Status object to populate dynamic fields on a SolrInputDocument instance.
+The default implementation provided in the project (`DefaultSolrInputDocumentMapper`) uses Java reflection to read data from a Java object to populate the fields of the SolrInputDocument. In the Twitter example, the default implementation uses Java reflection to read data from a Twitter4J Status object to populate dynamic fields on a SolrInputDocument instance.
 
-When using the default mapper, you must have dynamic fields enabled in your Solr schema.xml or have Solr's field guessing feature enabled for your collection, which is enabled by default for the data_driven_schema_configs configset. The default mapper bean is defined in the resources/storm-solr-spring.xml file as:
+When using the default mapper, you must have dynamic fields enabled in your Solr `schema.xml` or have Solr's field guessing feature enabled for your collection, which is enabled by default for the `data_driven_schema_configs` configset. The default mapper bean is defined in the `resources/storm-solr-spring.xml` file as:
 
 [source,xml]
 ----
@@ -288,13 +351,15 @@ When using the default mapper, you must have dynamic fields enabled in your Solr
   </bean>
 ----
 
-As discussed above, the ${fieldGuessingEnabled} variable will be resolved from the `Config.groovy` configuration file at runtime.
+As discussed above, the `${fieldGuessingEnabled}` variable will be resolved from the `Config.groovy` configuration file at runtime.
 
 It should be clear, however, that you can inject your own SolrInputDocumentMapper implementation into the bolt bean using Spring if the default implementation does not meet your needs.
+// end::field-mapping[]
 
-=== Working on a kerberized environment
+// tag::storm-kerberos[]
+=== Working on a Kerberized Environment
 
-The HdfsFileSystemProvider bean needs the Kerberos credentials (keytab and principal), by default the authentication is set to SIMPLE.
+The `HdfsFileSystemProvider` bean needs the Kerberos credentials (keytab and principal). By default the authentication is set to SIMPLE.
 
 [source,xml]
 ----
@@ -310,7 +375,7 @@ The HdfsFileSystemProvider bean needs the Kerberos credentials (keytab and princ
   </bean>
 ----
 
-The SolrSecurity bean needs the full path of jaas-client.conf [check https://cwiki.apache.org/confluence/display/solr/Security]. By default, the file is not set and no authentication will be perform.
+The `SolrSecurity` bean needs the full path of `jaas-client.conf` (see https://cwiki.apache.org/confluence/display/solr/Security). By default, the file is not set and no authentication will be performed.
 
 [source,xml]
 ----
@@ -320,7 +385,7 @@ The SolrSecurity bean needs the full path of jaas-client.conf [check https://cwi
   </bean>
 ----
 
-==== Environment-specific configuration example:
+*Environment-Specific Configuration Example*
 
 All the properties for the kerberized environment are optional.
 
@@ -349,21 +414,5 @@ All the properties for the kerberized environment are optional.
   }
 ----
 
-=== Working with MaprFS
-
-First, build the jar with mapr 5 dependencies.
-
-[literal]
-mvn clean package -Dmaven.test.skip=true -Dhadoop-version=mapr5
-
-
-This will generate the `target/storm-solr-1.0-mapr5-SNAPSHOT.jar` that contains the Storm JAR needed to deploy a topology.
-
-In order to execute the `hdfs-to-solr` example, add the spring `fs.hdfs.impl` property to your `Config.groovy` file with the `com.mapr.fs.MapRFileSystem` value. Also, change the `fs.defaultFS` property to use the maprfs schema.
-
-[source,groovy]
-----
-   spring.fs.defaultFS = "maprfs://cldbhost:port"
-   spring.fs.hdfs.impl = "com.mapr.fs.MapRFileSystem"
-
-----
+// end::storm-kerberos[]
+// end::topology[]

--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,7 @@ Tools for building Storm topologies for indexing data into SolrCloud.
 * Support for SolrCloud.
 
 // tag::storm-build[]
+
 == Getting Started
 
 First, build the Jar for this project:

--- a/README.adoc
+++ b/README.adoc
@@ -18,6 +18,8 @@ Tools for building Storm topologies for indexing data into SolrCloud.
 
 == Getting Started
 
+== Build the Jar
+
 First, build the Jar for this project:
 
 `mvn clean package`
@@ -74,7 +76,7 @@ public interface StormTopologyFactory {
 
 First, build the jar with MapR 5 dependencies.
 
-[literal]
+[source]
 mvn clean package -Dmaven.test.skip=true -Dhadoop-version=mapr5
 
 This will generate the `target/storm-solr-1.0-mapr5-SNAPSHOT.jar` that contains the Storm JAR needed to deploy a topology.
@@ -127,7 +129,7 @@ Lastly, this class is written in Groovy instead of Java, which helps keep things
 
 We’ll get into the specific details of the implementation shortly, but first, let’s see how to run the TwitterToSolrTopology using the `StreamingApp` framework. For local mode, you would do:
 
-[literal]
+[source]
 ....
 java -classpath $STORM_HOME/lib/*:target/storm-solr-1.0.jar com.lucidworks.storm.StreamingApp \
    example.twitter.TwitterToSolrTopology -localRunSecs 90
@@ -137,7 +139,7 @@ The command above will run the TwitterToSolrTopology for 90 seconds on your loca
 
 To submit to a remote cluster, you would do:
 
-[literal]
+[source]
 ....
 $STORM_HOME/bin/storm jar target/storm-solr-1.0.jar com.lucidworks.storm.StreamingApp \
    example.twitter.TwitterToSolrTopology -env staging
@@ -298,7 +300,7 @@ When adapting the project to your own requirements, the easiest approach is to u
 
 However, you can also specify a different `Config.groovy` file by using the `-config` command-line option when deploying the topology, such as:
 
-[literal]
+[source]
 ....
 $STORM_HOME/bin/storm jar target/storm-solr-1.0.jar com.lucidworks.storm.StreamingApp \
    example.twitter.TwitterToSolrTopology -env staging -config MyConfig.groovy

--- a/README.adoc
+++ b/README.adoc
@@ -1,15 +1,22 @@
-Lucidworks Storm/Solr Integration
-========
+= Lucidworks Storm/Solr Integration
+:doctype: book
+:toc: right
+:toclevels: 3
+:icons: font
+:linkattrs:
+:source-highlighter: pygments
+:pygments-style: tango
+:allow-uri-read:
+:sourcedir: src/main/groovy/com/lucidworks/storm/example/twitter
 
 Tools for building Storm topologies for indexing data into SolrCloud.
 
-Features
-========
+== Features
 
-* Send objects from a Storm topology into Solr
+* Send objects from a Storm topology into Solr.
+* Support for SolrCloud.
 
-Getting Started
-========
+== Getting Started
 
 First, build the Jar for this project:
 
@@ -17,8 +24,7 @@ First, build the Jar for this project:
 
 This will generate the `target/storm-solr-1.0.jar` that contains the Storm JAR needed to deploy a topology.
 
-Packaging and Running a Storm Topology
-========
+== Packaging and Running a Storm Topology
 
 To begin, let’s understand how to run a topology in Storm. Effectively, there are two basic modes of running a Storm topology: local and cluster mode. Local mode is great for testing your topology locally before pushing it out to a remote Storm cluster, such as staging or production. For starters, you need to compile and package your code and all of its dependencies into a single JAR with an main class that runs your topology.
 
@@ -26,7 +32,8 @@ For this project, I chose the Maven Shade plugin to create the unified JAR with 
 
 To run locally, you need to have some code that starts up a local cluster in the JVM, submits your topology, and then waits for some configurable amount of time before shutting it all back down, as shown in the following code:
 
-```
+[source,java]
+----
 LocalCluster cluster = new LocalCluster();
 cluster.submitTopology(topologyName, stormConf, topologyFactory.build(this));
 try {
@@ -34,12 +41,15 @@ try {
 } catch (InterruptedException ie) { ... }
 cluster.killTopology(topologyName);
 cluster.shutdown();
-```
+----
 
 However, if you want to run your topology in a remote cluster, such as production, you need to do something like:
-```
+
+[source,java]
+----
 StormSubmitter.submitTopology(topologyName, stormConf, topologyFactory.build(this));
-```
+----
+
 Consequently, the first thing you’ll need is some way to decide whether to run locally or submit to a remote cluster using some command-line switch when invoking your application. You’ll also need some way to pass along environment specific configuration options. For instance, the Solr you want to index into will be different between local, staging, and production. Let it suffice to say that launching and configuring a Storm topology ends up requiring a fair amount of common boilerplate code. To address this need, our project provides the com.lucidworks.storm.StreamingApp class that does the following:
 
 * Separates the process of defining a Storm topology from the process of running a Storm topology in different environments. This lets you focus on defining a topology for your specific requirements.
@@ -47,77 +57,62 @@ Consequently, the first thing you’ll need is some way to decide whether to run
 * Minimizes duplicated boilerplate code when developing multiple topologies and gives you a common place to insert reusable logic needed for all of your topologies.
 
 To use StreamingApp, you simply need to implement the StormTopologyFactory interface, which defines the spouts and bolts in your topology:
-```
+
+[source,java]
+----
 public interface StormTopologyFactory {
  String getName();
 
  StormTopology build(StreamingApp app) throws Exception;
 }
-```
+----
 
-Developing a Storm Topology
-========
+== Developing a Storm Topology
 
-Let's look at an example that indexes tweets from Twitter into SolrCloud
 
-TwitterToSolrTopology
--------------
+Let's look at an example that indexes tweets from Twitter into SolrCloud.
 
-```
-class TwitterToSolrTopology implements StormTopologyFactory {
+=== TwitterToSolrTopology
 
-  static final Fields spoutFields = new Fields("id", "tweet")
-
-  String getName() { return "twitter-to-solr" }
-
-  StormTopology build(StreamingApp app) throws Exception {
-    // setup spout and bolts for accessing Spring-managed POJOs at runtime
-    SpringSpout twitterSpout = new SpringSpout("twitterDataProvider", spoutFields);
-    SpringBolt solrBolt = new SpringBolt("solrBoltAction", app.tickRate("solrBolt"));
-
-    // wire up the topology to read tweets and send to Solr
-    TopologyBuilder builder = new TopologyBuilder()
-    builder.setSpout("twitterSpout", twitterSpout, app.parallelism("twitterSpout"))
-    builder.setBolt("solrBolt", solrBolt, app.parallelism("solrBolt"))
-           .shuffleGrouping("twitterSpout")
-
-    return builder.createTopology()
-  }
-}
-```
+[source,java]
+----
+include::{sourcedir}/TwitterToSolrTopology.groovy[lines="12..22,29..-1"]
+----
 
 A couple of things should stand out to you in this listing. First, there’s no command-line parsing, environment-specific configuration handling, or any code related to running this topology. All that you see here is code defining a StormTopology. Second, the code is quite easy to understand because it only does one thing. Lastly, this class is written in Groovy instead of Java, which helps keep things nice and tidy and I find Groovy to be more enjoyable to write. Of course if you don’t want to use Groovy, you can use Java, as the framework supports both seamlessly.
 
 We’ll get into the specific details of the implementation shortly, but first, let’s see how to run the TwitterToSolrTopology using the StreamingApp framework. For local mode, you would do:
 
-```
+[source]
+----
 java -classpath $STORM_HOME/lib/*:target/storm-solr-1.0.jar com.lucidworks.storm.StreamingApp \
-  example.twitter.TwitterToSolrTopology -localRunSecs 90
-```
+   example.twitter.TwitterToSolrTopology -localRunSecs 90
+----
 
 The command above will run the TwitterToSolrTopology for 90 seconds on your local workstation and then shutdown. All the setup work is provided by the StreamingApp class. To submit to a remote cluster, you would do:
 
-```
+[literal]
+....
 $STORM_HOME/bin/storm jar target/storm-solr-1.0.jar com.lucidworks.storm.StreamingApp \
    example.twitter.TwitterToSolrTopology -env staging
-```
+....
 
 Notice that I’m using the -env flag to indicate I’m running in my staging environment. It’s common to need to run a Storm topology in different environments, such as test, staging, and production, so that’s built into the StreamingApp framework.
 
-SpringBolt
--------------
+=== SpringBolt
 
 The `com.lucidworks.storm.spring.SpringBolt` class allows you to implement your bolt logic as a simple
 Spring-managed POJO. In the example above, the `SpringBolt` class delegates message processing logic to a
 Spring-managed bean with id `solrBoltAction`. The `solrBoltAction` bean is defined in the Spring container
 configuration file `resources/spring.xml` as:
 
-```
+[source,xml]
+----
   <bean id="solrBoltAction" class="com.lucidworks.storm.solr.SolrBoltAction">
     <property name="batchSize" value="100"/>
     <property name="bufferTimeoutMs" value="1000"/>
   </bean>
-```
+----
 
 The `SpringBolt` framework provides clean separation of concerns and allows you to leverage the full power of the
 Spring framework for developing your Storm topology. Moreover, this approach makes it easier to test your bolt action
@@ -126,43 +121,44 @@ logic in JUnit outside of the Storm framework.
 The `SolrBoltAction` bean also depends on an instance of the `CloudSolrClient` class from SolrJ to be auto-wired
 by the Spring framework:
 
-```
-  <bean id="cloudSolrClient" class="shaded.apache.solr.client.solrj.impl.CloudSolrClient">
-    <constructor-arg index="0" value="${zkHost}"/>
-    <property name="defaultCollection" value="${defaultCollection}"/>
-  </bean>
-```
+[source,xml]
+----
+ <bean id="cloudSolrClient" class="shaded.apache.solr.client.solrj.impl.CloudSolrClient">
+   <constructor-arg index="0" value="${zkHost}"/>
+   <property name="defaultCollection" value="${defaultCollection}"/>
+</bean>
+----
 
 The `zkHost` and `defaultCollection` properties are defined in `resources/Config.groovy`
 
-SpringSpout
--------------
+=== SpringSpout
 
 In Storm, a spout produces a stream of tuples. The TwitterToSolrTopology example uses an instance of SpringSpout and a Twitter data provider to stream tweets into the topology:
 
-```
+[literal]
 SpringSpout twitterSpout = new SpringSpout("twitterDataProvider", spoutFields);
-```
+
 
 SpringSpout allows you to focus on the application-specific logic needed to generate data without having to worry about Storm specific implementation details. As you might have guessed, the data provider is a Spring-managed POJO that implements the StreamingDataProvider interface:
 
-```
+[source,java]
+----
 public interface StreamingDataProvider {
- void open(Map stormConf);
+   void open(Map stormConf);
 
  boolean next(NamedValues record) throws Exception;
 }
-```
+----
 
 Take a look at the TwitterDataProvider implementation provided in the project as a starting point for implementing a Spring-managed bean for your topology.
 
 
-Unit Testing
--------------
+=== Unit Testing
 
 When writing a unit test, you don’t want to have to spin up a Storm cluster to test application-specific logic that doesn’t depend on Storm. Recall that one of the benefits of using this framework is that it separates business logic from Storm boilerplate code. Let’s look at some code from the unit test for our SolrBoltAction implementation.
 
-```
+[source,java]
+----
 @Test
 public void testBoltAction() throws Exception {
   // Spring @Autowired property at runtime
@@ -181,20 +177,20 @@ public void testBoltAction() throws Exception {
   cloudSolrServer.commit();
   ...
 }
-```
+----
 
 The first thing that you should notice is the unit test doesn’t need a Storm cluster to run. This makes your tests run quickly and helps isolate bugs since there are fewer runtime dependencies in this test. It’s also important to notice that the SolrBoltAction implementation is not running in a Spring-managed container in this unit test. We’re just creating the instance directly using the new operator. This is good test design as well since you don’t want to create a Spring container for every unit test and testing the Spring configuration is not the responsibility of this particular unit test.
 
 The unit test is also using Mockito to mock the Storm Tuple object that is passed into SolrBoltAction. Mockito makes it easy to mock complex objects in a unit test. The key take-away here is that the unit test focuses on verifying the SolrBoltAction implementation without having to worry about Storm or Spring.
 
-Environment-specific Configuration
--------------
+=== Environment-specific Configuration
 
-I’ve implemented several production Storm topologies in the past couple years and one pattern that keeps emerging is the need to manage configuration settings for different environments. For instance, we’ll need to index into a different SolrCloud cluster for staging and production. To address this need, the Spring-driven framework allows you to keep all environment-specific configuration properties in the same configuration file: Config.groovy.
+I’ve implemented several production Storm topologies in the past couple years and one pattern that keeps emerging is the need to manage configuration settings for different environments. For instance, we’ll need to index into a different SolrCloud cluster for staging and production. To address this need, the Spring-driven framework allows you to keep all environment-specific configuration properties in the same configuration file: `Config.groovy`.
 
-Don't worry if you don't know Groovy, the syntax of the Config.groovy file is very easy to understand and allows you to cleanly separate properties for the following environments: test, dev, staging, and production. Put simply, this approach allows you to run the topology in multiple environments using a simple command-line switch to specify the environment settings that should be applied -env. Here’s an example of Config.groovy that shows how to organize properties for the test, development, staging, and production environments:
+Don't worry if you don't know Groovy, the syntax of the `Config.groovy` file is very easy to understand and allows you to cleanly separate properties for the following environments: test, dev, staging, and production. Put simply, this approach allows you to run the topology in multiple environments using a simple command-line switch to specify the environment settings that should be applied -env. Here’s an example of `Config.groovy` that shows how to organize properties for the test, development, staging, and production environments:
 
-```
+[source,groovy]
+----
 environments {
 
  twitterSpout.parallelism = 1
@@ -235,43 +231,48 @@ environments {
    spring.fieldGuessingEnabled = false
  }
 }
-```
+----
 
-Notice that all dynamic variables used in the resources/storm-solr-spring.xml must be prefixed with "spring." in Config.groovy. For instance, the ${zkHost} setting in storm-solr-spring.xml resolves to the spring.zkHost property in Config.groovy.
+Notice that all dynamic variables used in the resources/storm-solr-spring.xml must be prefixed with "spring." in `Config.groovy`. For instance, the ${zkHost} setting in storm-solr-spring.xml resolves to the spring.zkHost property in `Config.groovy`.
 
-You can also configure all Storm-topology related properties in the Config.groovy file. For instance, if you need to change the topology.max.task.parallelism property for your topology, you can set that in Config.groovy.
+You can also configure all Storm-topology related properties in the `Config.groovy` file. For instance, if you need to change the topology.max.task.parallelism property for your topology, you can set that in `Config.groovy`.
 
-When adapting the project to your own requirements, the easiest approach is to update the resources/Config.groovy with the configuration settings for each of your environments and then rebuild the Job JAR. However, you can also specify a different Config.groovy file by using the -config command-line option when deploying the topology, such as:
+When adapting the project to your own requirements, the easiest approach is to update the `resources/Config.groovy` with the configuration settings for each of your environments and then rebuild the Job JAR. However, you can also specify a different `Config.groovy` file by using the -config command-line option when deploying the topology, such as:
 
-```
+[literal]
+....
 $STORM_HOME/bin/storm jar target/storm-solr-1.0.jar com.lucidworks.storm.StreamingApp \
    example.twitter.TwitterToSolrTopology -env staging -config MyConfig.groovy
-```
+....
 
-Metrics
--------------
+=== Metrics
 
 Storm provides high-level metrics for bolts and spouts, but if you need more visibility into the inner workings of your application-specific logic, then it’s common to use the Java metrics library, see: https://dropwizard.github.io/metrics/3.1.0/. Fortunately, there are open source options for integrating metrics with Spring, see: https://github.com/ryantenney/metrics-spring.
 
 The Spring context configuration file resources/storm-solr-spring.xml comes pre-configured with all the infrastructure needed to inject metrics into your bean implementations:
-```
+
+[source,xml]
+----
 <metrics:metric-registry id="metrics"/>
 <metrics:annotation-driven metric-registry="metrics"/>
 <metrics:reporter type="slf4j" metric-registry="metrics" period="1m"/>
-```
+----
+
 By default, the project is configured to log metrics once a minute to the Storm log using the slf4j reporter.
 
 When implementing your StreamingDataAction (bolt) or StreamingDataProvider (spout), you can have Spring auto-wire metrics objects using the @Metric annotation when declaring metrics-related member variables. For instance, the SolrBoltAction class uses a Timer to track how long it takes to send batches to Solr.
-```
+
+[source,java]
+----
 @Metric
 public Timer sendBatchToSolr;
-```
+----
+
 The SolrBoltAction class provides several examples of how to use metrics in your bean implementations.
 
 Before moving on to some Solr specific features in the framework, I want drive home one more point. The example Twitter topology we’ve been working with in this blog is quite trivial. In practice, most topologies are more complex and have many spouts and bolts, typically written by multiple developers. Moreover, topologies tend to evolve over time to incorporate data from new systems and requirements. Using this framework will help you craft complex topologies in a simple, maintainable fashion.
 
-Field Mapping
--------------
+=== Field Mapping
 
 The SolrBoltAction bean takes care of sending documents to SolrCloud in an efficient manner, but it only works with SolrInputDocument objects from SolrJ. It’s unlikely that your Storm topology will be working with SolrInputDocument objects natively, so the SolrBoltAction bean delegates mapping of input Tuples to SolrInputDocument objects to a Spring-managed bean that implements the com.lucidworks.storm.solr.SolrInputDocumentMapper interface. This fits nicely with our design approach of separating concerns in our topology.
 
@@ -279,23 +280,24 @@ The default implementation provided in the project (DefaultSolrInputDocumentMapp
 
 When using the default mapper, you must have dynamic fields enabled in your Solr schema.xml or have Solr's field guessing feature enabled for your collection, which is enabled by default for the data_driven_schema_configs configset. The default mapper bean is defined in the resources/storm-solr-spring.xml file as:
 
-```
+[source,xml]
+----
   <bean id="solrInputDocumentMapper"
         class="com.lucidworks.storm.solr.DefaultSolrInputDocumentMapper">
     <property name="fieldGuessingEnabled" value="${fieldGuessingEnabled}"/>
   </bean>
-```
+----
 
-As discussed above, the ${fieldGuessingEnabled} variable will be resolved from the Config.groovy configuration file at runtime.
+As discussed above, the ${fieldGuessingEnabled} variable will be resolved from the `Config.groovy` configuration file at runtime.
 
 It should be clear, however, that you can inject your own SolrInputDocumentMapper implementation into the bolt bean using Spring if the default implementation does not meet your needs.
 
-Working on a kerberized environment
------------------------------------
+=== Working on a kerberized environment
 
 The HdfsFileSystemProvider bean needs the Kerberos credentials (keytab and principal), by default the authentication is set to SIMPLE.
 
-```
+[source,xml]
+----
   <bean id="hdfsFileSystemProvider" class="com.lucidworks.storm.example.hdfs.HdfsFileSystemProvider">
     <property name="hdfsConfig">
       <map>
@@ -306,22 +308,24 @@ The HdfsFileSystemProvider bean needs the Kerberos credentials (keytab and princ
       </map>
     </property>
   </bean>
-```
+----
 
 The SolrSecurity bean needs the full path of jaas-client.conf [check https://cwiki.apache.org/confluence/display/solr/Security]. By default, the file is not set and no authentication will be perform.
 
-```
+[source,xml]
+----
   <bean id="solrSecurity" class="com.lucidworks.storm.utils.SolrSecurity" init-method="setConfigigurer">
      <property name="solrJaasFile" value="${solrJaasFile:}"/>
      <property name="solrJaasAppName" value="${solrJaasAppName:}"/>
   </bean>
-```
+----
 
-Environment-specific configuration example:
+==== Environment-specific configuration example:
 
 All the properties for the kerberized environment are optional.
 
-```
+[source,groovy]
+----
   production {
     env.name = "production"
 
@@ -343,25 +347,23 @@ All the properties for the kerberized environment are optional.
     spring.solrJaasFile = "/path/to/jaas-client.conf"
     spring.solrJaasAppName = "Client"
   }
-```
+----
 
-Working with MaprFS
--------------------
+=== Working with MaprFS
 
 First, build the jar with mapr 5 dependencies.
 
-```
+[literal]
 mvn clean package -Dmaven.test.skip=true -Dhadoop-version=mapr5
-```
+
 
 This will generate the `target/storm-solr-1.0-mapr5-SNAPSHOT.jar` that contains the Storm JAR needed to deploy a topology.
 
+In order to execute the `hdfs-to-solr` example, add the spring `fs.hdfs.impl` property to your `Config.groovy` file with the `com.mapr.fs.MapRFileSystem` value. Also, change the `fs.defaultFS` property to use the maprfs schema.
 
-
-In order to execute the `hdfs-to-solr` example, add the spring `fs.hdfs.impl` property to your Config.groovy file with the `com.mapr.fs.MapRFileSystem` value. Also, change the `fs.defaultFS` property to use the maprfs schema.
-
-```
+[source,groovy]
+----
    spring.fs.defaultFS = "maprfs://cldbhost:port"
    spring.fs.hdfs.impl = "com.mapr.fs.MapRFileSystem"
 
-```
+----


### PR DESCRIPTION
This change converts the README from Markdown to Asciidoc format. This change allows greater control over the README content and allows standardization of Lucidworks-maintained documentation to Asciidoc format. Github supports this format, so it appears to users of the Github web UI as a standard README file.